### PR TITLE
Add quiz navigation and results page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,12 @@
 </select>
 </div>
 <div id="quiz"></div>
-<button id="submit" style="display:none;">Submit</button>
-<div id="result"></div>
+<div id="quiz-controls">
+  <button id="back" style="display:none;">Back</button>
+  <button id="skip" style="display:none;">Skip</button>
+  <button id="restart">Restart</button>
+  <button id="submit" style="display:none;">Submit</button>
+</div>
 <script src="step3pt.js"></script>
 <script src="script.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A quizz to decide your 2024 D&D character",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "keywords": [],
   "author": "",

--- a/results.html
+++ b/results.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Quiz Results</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Quiz Results</h1>
+<div id="results"></div>
+<button id="restart">Restart Quiz</button>
+<script src="results.js"></script>
+</body>
+</html>

--- a/results.js
+++ b/results.js
@@ -1,0 +1,94 @@
+(function(){
+  const container = document.getElementById('results');
+  const restartBtn = document.getElementById('restart');
+  const stored = sessionStorage.getItem('dndResults');
+  if(!stored){
+    container.textContent = 'No results available.';
+    return;
+  }
+  const {species, class:clazz, background, images, lang} = JSON.parse(stored);
+
+  const speciesInfo = {
+    'Aasimar':'Humanoides tocados pelo plano celestial.',
+    'Dragonborn':'Descendentes de dragões, orgulhosos e poderosos.',
+    'Dwarf':'Anões resistentes e trabalhadores.',
+    'Elf':'Elfos graciosos e longevos.',
+    'Gnome':'Pequenos inventores e curiosos.',
+    'Goliath':'Gigantes das montanhas, focados em força.',
+    'Halfling':'Pessoas pequenas e de grande coração.',
+    'Human':'Versáteis e ambiciosos.',
+    'Orc':'Guerreiros ferozes de sangue quente.',
+    'Tiefling':'Herança infernal e poderes sombrios.',
+    'Aarakocra':'Seres alados que habitam os céus.',
+    'Bugbear':'Criaturas grandes e furtivas.',
+    'Centaur':'Metade humano, metade cavalo.',
+    'Firbolg':'Gigantes gentis ligados à natureza.',
+    'Githyanki':'Guerreiros de outros planos.',
+    'Githzerai':'Monges que controlam a mente.',
+    'Goblin':'Pequenos e astutos sobreviventes.',
+    'Hobgoblin':'Estratégas disciplinados.',
+    'Kobold':'Serviçais dracónicos engenhosos.',
+    'Lizardfolk':'Humanóides répteis frios e práticos.',
+    'Minotaur':'Lutadores com cabeça de touro.',
+    'Satyr':'Festeiros meio-bode.',
+    'Tabaxi':'Felinos curiosos e ágeis.',
+    'Triton':'Guardas nobres dos mares.',
+    'Yuan-ti':'Seres serpentes manipuladores.'
+  };
+
+  const classInfo = {
+    'Barbarian':'Guerreiro guiado pela fúria.',
+    'Bard':'A magia da música e da inspiração.',
+    'Cleric':'Servos divinos que curam e castigam.',
+    'Druid':'Guardião das forças naturais.',
+    'Fighter':'Especialista em combate versátil.',
+    'Monk':'Mestre de artes marciais e disciplina.',
+    'Paladin':'Campeão de ideais sagrados.',
+    'Ranger':'Explorador e caçador do ermo.',
+    'Rogue':'Especialista em furtividade e truques.',
+    'Sorcerer':'Magia inata e poderosa.',
+    'Warlock':'Pactos com entidades misteriosas.',
+    'Wizard':'Estudioso das artes arcanas.'
+  };
+
+  const backgroundInfo = {
+    'Acolyte':'Treinado em templos ou igrejas.',
+    'Artisan':'Especialista em ofícios e ferramentas.',
+    'Charlatan':'Mestre do embuste e engano.',
+    'Criminal':'Habituado ao submundo ilegal.',
+    'Entertainer':'Artista que vive de atuar.',
+    'Farmer':'Quem trabalha a terra e colhe frutos.',
+    'Guard':'Responsável por proteger outros.',
+    'Guide':'Conhecedor de trilhos e rotas.',
+    'Hermit':'Recluso em busca de iluminação.',
+    'Merchant':'Vive de comprar e vender bens.',
+    'Noble':'Criado no conforto e na política.',
+    'Sage':'Erudito sedento por conhecimento.',
+    'Sailor':'Acostumado ao mar e suas tempestades.',
+    'Scribe':'Especialista em registos e documentos.',
+    'Soldier':'Treinado nas artes da guerra.',
+    'Wayfarer':'Viajante que não fixa morada.'
+  };
+
+  const p = document.createElement('p');
+  p.innerHTML = `<strong>Species:</strong> ${species} - ${speciesInfo[species] || ''}<br>`+
+                 `<strong>Class:</strong> ${clazz} - ${classInfo[clazz] || ''}<br>`+
+                 `<strong>Background:</strong> ${background} - ${backgroundInfo[background] || ''}`;
+  container.appendChild(p);
+
+  if(images && images.length){
+    images.forEach(url => {
+      const img = document.createElement('img');
+      img.src = url;
+      img.alt = 'character';
+      img.style.maxWidth = '200px';
+      img.style.marginRight = '10px';
+      container.appendChild(img);
+    });
+  }
+
+  restartBtn.addEventListener('click', () => {
+    sessionStorage.removeItem('dndResults');
+    window.location.href = 'index.html';
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -57,3 +57,7 @@ if (require.main === module) {
 }
 
 module.exports = server;
+  });
+}
+
+module.exports = server;

--- a/server.js
+++ b/server.js
@@ -21,6 +21,22 @@ const server = http.createServer((req, res) => {
       });
       return;
     }
+    if (req.url === '/results.html') {
+      fs.readFile('results.html', (err, data) => {
+        if (err) return res.end('Error');
+        res.writeHead(200, {'Content-Type':'text/html'});
+        res.end(data);
+      });
+      return;
+    }
+    if (req.url === '/results.js') {
+      fs.readFile('results.js', (err, data) => {
+        if (err) return res.end('Error');
+        res.writeHead(200, {'Content-Type':'application/javascript'});
+        res.end(data);
+      });
+      return;
+    }
     if (req.url === '/script.js') {
       fs.readFile('script.js', (err, data) => {
         if (err) return res.end('Error');

--- a/server.js
+++ b/server.js
@@ -50,6 +50,10 @@ const server = http.createServer((req, res) => {
   res.end('Not found');
 });
 
-server.listen(port, () => {
-  console.log(`Server running on http://localhost:${port}`);
-});
+if (require.main === module) {
+  server.listen(port, () => {
+    console.log(`Server running on http://localhost:${port}`);
+  });
+}
+
+module.exports = server;

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
 body {font-family: Arial, sans-serif; padding:20px;}
 #quiz section {margin-bottom: 20px;}
 label {display:block; margin:5px 0;}
+#quiz-controls {margin-top:20px;}
+#quiz-controls button {margin-right:5px;}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+const http = require('node:http');
+const assert = require('node:assert');
+const server = require('./server');
+
+const port = 3000;
+server.listen(port, () => {
+  http.get(`http://localhost:${port}`, res => {
+    try {
+      assert.strictEqual(res.statusCode, 200);
+      console.log('Index returned 200');
+      console.log('All tests passed');
+    } finally {
+      server.close();
+    }
+  }).on('error', err => {
+    console.error('Request failed', err);
+    server.close(() => process.exit(1));
+  });
+});


### PR DESCRIPTION
## Summary
- add navigation controls to return, skip and restart
- create dedicated results page
- show brief descriptions and generated images for the character
- store results in session storage
- update server to serve new assets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ae731c88325b9718247f3315b9e