### PR TITLE
Add button translations and fix server

### DIFF
--- a/results.js
+++ b/results.js
@@ -87,6 +87,8 @@
     });
   }
 
+  restartBtn.textContent = lang === 'pt' ? 'Recomeçar' : 'Restart Quiz';
+
   restartBtn.addEventListener('click', () => {
     sessionStorage.removeItem('dndResults');
     window.location.href = 'index.html';

--- a/script.js
+++ b/script.js
@@ -451,6 +451,9 @@ function renderQuiz() {
   submitBtn.style.display = 'block';
   backBtn.style.display = stage > 1 ? 'inline-block' : 'none';
   skipBtn.style.display = stage < 3 ? 'inline-block' : 'none';
+  backBtn.textContent = currentLang === 'pt' ? 'Recuar' : 'Back';
+  restartBtn.textContent = currentLang === 'pt' ? 'Recomeçar' : 'Restart';
+  skipBtn.textContent = currentLang === 'pt' ? 'Saltar' : 'Skip';
 }
 
 langSelect.addEventListener('change', () => {

--- a/server.js
+++ b/server.js
@@ -57,7 +57,3 @@ if (require.main === module) {
 }
 
 module.exports = server;
-  });
-}
-
-module.exports = server;


### PR DESCRIPTION
## Summary
- localize navigation buttons so they display Portuguese text
- show translated restart button on results page
- fix malformed `server.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d1d785b18832583968dbb057c9b45