### PR TITLE
Rearrange quiz buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<button id="restart">Restart</button>
 <h1>D&D Character Quiz</h1>
 <div id="language-select">
 <label for="lang">Language:</label>
@@ -17,9 +18,8 @@
 </div>
 <div id="quiz"></div>
 <div id="quiz-controls">
-  <button id="back" style="display:none;">Back</button>
-  <button id="restart">Restart</button>
   <button id="submit" style="display:none;">Submit</button>
+  <button id="back" style="display:none;">Back</button>
 </div>
 <script src="step3pt.js"></script>
 <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -448,7 +448,7 @@ function renderQuiz() {
   }
   quizDiv.innerHTML = html;
   submitBtn.style.display = 'block';
-  backBtn.style.display = stage > 1 ? 'inline-block' : 'none';
+  backBtn.style.display = stage > 1 ? 'block' : 'none';
   backBtn.textContent = currentLang === 'pt' ? 'Recuar' : 'Back';
   restartBtn.textContent = currentLang === 'pt' ? 'Recomeçar' : 'Restart';
 }

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
-body {font-family: Arial, sans-serif; padding:20px;}
+body {font-family: Arial, sans-serif; padding:20px; position:relative; padding-top:60px;}
 #quiz section {margin-bottom: 20px;}
 label {display:block; margin:5px 0;}
-#quiz-controls {margin-top:20px;}
-#quiz-controls button {margin-right:5px;}
+#restart {position:absolute; top:20px; left:20px;}
+#quiz-controls {margin-top:20px; display:flex; flex-direction:column; align-items:flex-start;}
+#quiz-controls button {margin-bottom:5px;}


### PR DESCRIPTION
## Summary
- move restart button to the top-left corner of the page
- place submit button above the back button
- adjust styles for new button order and layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d435770f48325ad3c607e79f1ade8