### PR TITLE
Fix duplicate subquestion declarations

### DIFF
--- a/classQuestions.js
+++ b/classQuestions.js
@@ -304,4 +304,10 @@ const subClassPT = {
   }
 };
 
-const subClassQuestions = { en: subClassEN, pt: subClassPT };
+// The subclass questions are also exposed globally so that the main quiz
+// script can access them. Using `||=` avoids redeclaration errors if this
+// file gets included multiple times.
+window.subClassQuestions = window.subClassQuestions || {
+  en: subClassEN,
+  pt: subClassPT
+};

--- a/speciesQuestions.js
+++ b/speciesQuestions.js
@@ -441,4 +441,10 @@ const subQuestionsPT = {
   }
 };
 
-const subSpeciesQuestions = { en: subQuestionsEN, pt: subQuestionsPT };
+// expose the sub-species data on the global object. Using a conditional
+// assignment prevents errors if this script is accidentally loaded more
+// than once in the browser.
+window.subSpeciesQuestions = window.subSpeciesQuestions || {
+  en: subQuestionsEN,
+  pt: subQuestionsPT
+};


### PR DESCRIPTION
## Summary
- avoid redeclaration errors when loading question scripts multiple times
- expose `subSpeciesQuestions` and `subClassQuestions` using conditional assignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c958d3548325a8ca051ef844da1f