### PR TITLE
Adjust results display and background labels

### DIFF
--- a/backgroundQuestions.js
+++ b/backgroundQuestions.js
@@ -45,3 +45,43 @@ const step3en = {
     'Intelligence': ['Acolyte','Artisan','Criminal','Guard','Merchant','Noble','Sage','Scribe']
   }
 };
+
+const bgDescriptionsPT = {
+  Acolyte: 'Conhecedor de tradições sagradas e serviço comunitário',
+  Artisan: 'Trabalhador manual habilidoso',
+  Charlatan: 'Mestre em enganar com astúcia',
+  Criminal: 'Habituado a agir nas sombras',
+  Entertainer: 'Vive do aplauso e sabe cativar o público',
+  Farmer: 'Força adquirida no campo e vida simples',
+  Guard: 'Treinado para vigiar e proteger',
+  Guide: 'Especialista em trilhos e regiões perigosas',
+  Hermit: 'Costuma viver em isolamento e reflexão',
+  Merchant: 'Negociante experiente em trocas',
+  Noble: 'Conhecedor de etiqueta e círculos de poder',
+  Sage: 'Dedicado ao estudo e à busca de conhecimento',
+  Sailor: 'Adaptado à vida em embarcações',
+  Scribe: 'Habituado a copiar e guardar textos',
+  Soldier: 'Treinado para combate organizado',
+  Wayfarer: 'Sobrevivente de rua que se move silenciosamente'
+};
+
+const bgDescriptionsEN = {
+  Acolyte: 'Familiar with sacred rites and community duties',
+  Artisan: 'Skilled manual worker',
+  Charlatan: 'Expert at deceiving others',
+  Criminal: 'Used to acting from the shadows',
+  Entertainer: 'Lives for applause and charming crowds',
+  Farmer: 'Strength from a life of hard field work',
+  Guard: 'Trained to watch and protect',
+  Guide: 'Knows dangerous trails and wild regions',
+  Hermit: 'Accustomed to isolation and introspection',
+  Merchant: 'Seasoned in negotiation and trade',
+  Noble: 'Understands etiquette and circles of influence',
+  Sage: 'Devoted to study and knowledge',
+  Sailor: 'Adapted to life aboard ships',
+  Scribe: 'Works with copying and preserving texts',
+  Soldier: 'Trained for organized combat',
+  Wayfarer: 'Street survivor who moves unseen'
+};
+
+window.bgDescriptions = { pt: bgDescriptionsPT, en: bgDescriptionsEN };

--- a/results.js
+++ b/results.js
@@ -97,17 +97,6 @@
       'classes',
       displayClass
     );
-    if(style){
-      makeSection(
-        labels[currentLang].Style,
-        style,
-        '',
-        '',
-        undefined,
-        '',
-        style
-      );
-    }
     const baseBg = background ? background.replace(/\s*\(.*?\)\s*$/, '').trim() : background;
     const bgDesc = localizeInfo(backgroundInfo[currentLang][baseBg] || '', 'backgrounds');
     let displayBg = baseBg;

--- a/script.js
+++ b/script.js
@@ -156,7 +156,8 @@ function renderQuiz() {
     html += `<section><p>${step.question}</p>`;
     list.forEach((bg, i) => {
       const id = `bg_${i}`;
-      html += `<label><input type="radio" name="bg" value="${bg}" id="${id}"> ${strip(bg)}</label>`;
+      const desc = (bgDescriptions[currentLang] && bgDescriptions[currentLang][bg]) || strip(bg);
+      html += `<label><input type="radio" name="bg" value="${bg}" id="${id}"> ${desc}</label>`;
     });
     html += '</section>';
     submitBtn.textContent = currentLang === 'pt' ? 'Concluir' : 'Finish';


### PR DESCRIPTION
## Summary
- hide playing style on the results page
- describe backgrounds without using their names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c5b78f6408325ac92cfbaebeac3ff