### PR TITLE
Add subcategory and familiar prompts

### DIFF
--- a/results.js
+++ b/results.js
@@ -7,7 +7,7 @@
 
   const stored = sessionStorage.getItem('dndResults');
   const parsed = stored ? JSON.parse(stored) : {lang:'en'};
-  const {species, class:clazz, subclass, style, background, gender, height} = parsed;
+  const {species, class:clazz, subclass, style, background, gender, height, subcategoryName, subcategory, familiar} = parsed;
   let currentLang = parsed.lang || 'en';
 
   const phbSpecies = new Set([
@@ -186,7 +186,12 @@
 
     const promptSpecies = species;
     const promptBackground = background;
-    const prompt = `A ${genderMap[gender] || ''} ${promptSpecies}, standing ${heightText}, dressed in a way that reflects their role as a ${displayClassEn}. Their look shows traits of a ${promptBackground} — with appropriate gear or attitude. Dynamic fantasy character portrait${pose}, high detail, cinematic lighting, full body or 3/4 view. Dungeons & Dragons-inspired.`;
+    const promptSubcategory = subcategory || '';
+    const promptFamiliar = familiar || '';
+    const familiarSize = familiar ? (familiar === 'Skeleton' ? 'Medium' : 'Tiny') : '';
+    const subText = subcategoryName && promptSubcategory ? ` with ${subcategoryName} ${promptSubcategory}` : '';
+    const famText = promptFamiliar ? ` and a ${familiarSize} ${promptFamiliar} familiar` : '';
+    const prompt = `A ${genderMap[gender] || ''} ${promptSpecies}, standing ${heightText}, dressed in a way that reflects their role as a ${displayClassEn}${subText}${famText}. Their look shows traits of a ${promptBackground} — with appropriate gear or attitude. Dynamic fantasy character portrait${pose}, high detail, cinematic lighting, full body or 3/4 view. Dungeons & Dragons-inspired.`;
 
     const promptTitle = document.createElement('h2');
     promptTitle.textContent = miscText[currentLang].promptIntro;

--- a/styleQuestions.js
+++ b/styleQuestions.js
@@ -647,3 +647,84 @@ const styleQuizEN = {
 };
 
 window.styleQuiz = window.styleQuiz || { pt: styleQuizPT, en: styleQuizEN };
+
+const subCategoryPT = {
+  Druid: {
+    name: 'Ordem Primal',
+    question: 'Qual é a tua Ordem Primal?',
+    options: { Warden: 'Warden', Magician: 'Magician' }
+  },
+  Cleric: {
+    name: 'Ordem Divina',
+    question: 'Qual é a tua Ordem Divina?',
+    options: { Protector: 'Protetor', Thaumaturge: 'Taumaturgo' }
+  },
+  Warlock: {
+    name: 'Pactos de Invocação',
+    question: 'Que Pacto potencia as tuas invocações?',
+    options: {
+      'Pact of the Tome': 'Pacto do Tomo',
+      'Pact of the Chain': 'Pacto da Corrente',
+      'Pact of the Blade': 'Pacto da Lâmina',
+      None: 'Nenhum'
+    }
+  }
+};
+
+const subCategoryEN = {
+  Druid: {
+    name: 'Primal Order',
+    question: 'Which Primal Order do you follow?',
+    options: { Warden: 'Warden', Magician: 'Magician' }
+  },
+  Cleric: {
+    name: 'Divine Order',
+    question: 'Which Divine Order do you serve?',
+    options: { Protector: 'Protector', Thaumaturge: 'Thaumaturge' }
+  },
+  Warlock: {
+    name: 'Pact Eldritch Invocations',
+    question: 'Which Pact boon empowers your invocations?',
+    options: {
+      'Pact of the Tome': 'Pact of the Tome',
+      'Pact of the Chain': 'Pact of the Chain',
+      'Pact of the Blade': 'Pact of the Blade',
+      None: 'None'
+    }
+  }
+};
+
+const familiarPT = {
+  question: 'Que familiar te acompanha?',
+  options: {
+    Imp: 'Imp',
+    Pseudodragon: 'Pseudodragon',
+    Quasit: 'Quasit',
+    Skeleton: 'Skeleton',
+    'Slaad Tadpole': 'Slaad Tadpole',
+    'Sphinx of Wonder': 'Sphinx of Wonder',
+    Sprite: 'Sprite',
+    'Venomous Snake': 'Venomous Snake'
+  }
+};
+
+const familiarEN = {
+  question: 'Which familiar accompanies you?',
+  options: {
+    Imp: 'Imp',
+    Pseudodragon: 'Pseudodragon',
+    Quasit: 'Quasit',
+    Skeleton: 'Skeleton',
+    'Slaad Tadpole': 'Slaad Tadpole',
+    'Sphinx of Wonder': 'Sphinx of Wonder',
+    Sprite: 'Sprite',
+    'Venomous Snake': 'Venomous Snake'
+  }
+};
+
+window.subCategoryQuiz = window.subCategoryQuiz || {
+  pt: subCategoryPT,
+  en: subCategoryEN
+};
+
+window.familiarQuiz = window.familiarQuiz || { pt: familiarPT, en: familiarEN };


### PR DESCRIPTION
## Summary
- expand playing style questions with class subcategories and familiars
- track new quiz fields for class subcategory and familiar
- include subcategory and familiar in the AI prompt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ce21b23ec8325b48c2339a976807d