### PR TITLE
Implement new quiz flow

### DIFF
--- a/results.js
+++ b/results.js
@@ -72,6 +72,30 @@
       'species'
     );
 
+    const baseBg = background ? background.replace(/\s*\(.*?\)\s*$/, '').trim() : background;
+    const bgDesc = localizeInfo(backgroundInfo[currentLang][baseBg] || '', 'backgrounds');
+    let displayBg = baseBg;
+    if(nameMap[currentLang] && nameMap[currentLang].backgrounds && baseBg){
+      const translated = nameMap[currentLang].backgrounds[baseBg];
+      if(translated) {
+        displayBg = translated;
+      }
+    }
+    const abilityText = style || '';
+    const prefix = baseBg ? (currentLang === 'pt'
+      ? `Cultivaste a tua ${abilityText} como ${displayBg}. `
+      : `You cultivated your ${abilityText} as a ${displayBg}. `)
+      : '';
+    makeSection(
+      labels[currentLang].Background,
+      baseBg,
+      prefix + bgDesc,
+      'backgrounds',
+      'xphb',
+      'backgrounds',
+      displayBg
+    );
+
     const className = nameMap[currentLang].classes[clazz] || clazz;
     let subclassName = subclass ? subclass : '';
     if(subclass && nameMap[currentLang].subclasses){
@@ -96,24 +120,6 @@
       'xphb',
       'classes',
       displayClass
-    );
-    const baseBg = background ? background.replace(/\s*\(.*?\)\s*$/, '').trim() : background;
-    const bgDesc = localizeInfo(backgroundInfo[currentLang][baseBg] || '', 'backgrounds');
-    let displayBg = baseBg;
-    if(nameMap[currentLang] && nameMap[currentLang].backgrounds && baseBg){
-      const translated = nameMap[currentLang].backgrounds[baseBg];
-      if(translated) {
-        displayBg = translated;
-      }
-    }
-    makeSection(
-      labels[currentLang].Background,
-      baseBg,
-      bgDesc,
-      'backgrounds',
-      'xphb',
-      'backgrounds',
-      displayBg
     );
 
     const genderMap = {F:'female', M:'male', A:'androgynous'};
@@ -199,8 +205,15 @@
     promptEl.id = 'ai-prompt';
     promptEl.readOnly = true;
     promptEl.value = prompt;
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = currentLang === 'pt' ? 'Copiar' : 'Copy';
+    copyBtn.addEventListener('click', ()=>{
+      promptEl.select();
+      document.execCommand('copy');
+    });
     container.appendChild(promptTitle);
     container.appendChild(promptEl);
+    container.appendChild(copyBtn);
   }
 
   langSelect.addEventListener('change', () => {

--- a/script.js
+++ b/script.js
@@ -39,7 +39,8 @@ let currentResult = {
   background: null,
   subcategoryName: null,
   subcategory: null,
-  familiar: null
+  familiar: null,
+  specialStyle: null
 };
 let speciesNode = null;
 const speciesStack = [];
@@ -55,6 +56,7 @@ let styleNode = null;
 const styleStack = [];
 let subCategoryNode = null;
 let familiarNode = null;
+let specialStyleNode = null;
 
 function renderQuiz() {
   const locale = data[currentLang];
@@ -138,19 +140,19 @@ function renderQuiz() {
     submitBtn.textContent = currentLang === 'pt' ? 'Avançar' : 'Next';
   } else if(stage === 4){
     html += `<h2>${currentLang === 'pt' ? 'Estilo de Jogo' : 'Playing Style'}</h2>`;
-    if(styleNode){
-      html += `<section><p>${styleNode.question}</p>`;
-      for(const key in styleNode.options){
-        const id = `style_${key}`;
-        html += `<label><input type="radio" name="style" value="${key}" id="${id}"> ${strip(styleNode.options[key].label)}</label>`;
-      }
-      html += '</section>';
-      submitBtn.textContent = currentLang === 'pt' ? 'Avançar' : 'Next';
-    } else if(subCategoryNode){
+    if(subCategoryNode){
       html += `<section><p>${subCategoryNode.question}</p>`;
       for(const key in subCategoryNode.options){
         const id = `subc_${key}`;
         html += `<label><input type="radio" name="subcategory" value="${key}" id="${id}"> ${strip(subCategoryNode.options[key])}</label>`;
+      }
+      html += '</section>';
+      submitBtn.textContent = currentLang === 'pt' ? 'Avançar' : 'Next';
+    } else if(specialStyleNode){
+      html += `<section><p>${specialStyleNode.question}</p>`;
+      for(const key in specialStyleNode.options){
+        const id = `ss_${key}`;
+        html += `<label><input type="radio" name="specialstyle" value="${key}" id="${id}"> ${strip(specialStyleNode.options[key])}</label>`;
       }
       html += '</section>';
       submitBtn.textContent = currentLang === 'pt' ? 'Avançar' : 'Next';
@@ -159,6 +161,14 @@ function renderQuiz() {
       for(const key in familiarNode.options){
         const id = `fam_${key.replace(/\s/g,'')}`;
         html += `<label><input type="radio" name="familiar" value="${key}" id="${id}"> ${strip(familiarNode.options[key])}</label>`;
+      }
+      html += '</section>';
+      submitBtn.textContent = currentLang === 'pt' ? 'Avançar' : 'Next';
+    } else if(styleNode){
+      html += `<section><p>${styleNode.question}</p>`;
+      for(const key in styleNode.options){
+        const id = `style_${key}`;
+        html += `<label><input type="radio" name="style" value="${key}" id="${id}"> ${strip(styleNode.options[key].label)}</label>`;
       }
       html += '</section>';
       submitBtn.textContent = currentLang === 'pt' ? 'Avançar' : 'Next';
@@ -196,7 +206,7 @@ function renderQuiz() {
   quizDiv.innerHTML = html;
   window.scrollTo(0,0);
   submitBtn.style.display = 'block';
-  backBtn.style.display = stage > 0 || speciesStack.length > 0 || subSpeciesNode || classStack.length > 0 || styleStack.length > 0 || subCategoryNode || familiarNode ? 'block' : 'none';
+  backBtn.style.display = stage > 0 || speciesStack.length > 0 || subSpeciesNode || classStack.length > 0 || styleStack.length > 0 || subCategoryNode || familiarNode || specialStyleNode ? 'block' : 'none';
   backBtn.textContent = currentLang === 'pt' ? 'Recuar' : 'Back';
   restartBtn.textContent = labels[currentLang].restart;
 }
@@ -245,6 +255,11 @@ langSelect.addEventListener('change', () => {
     subCategoryNode = subCategoryQuiz[currentLang][currentResult.class];
   } else {
     subCategoryNode = null;
+  }
+  if(specialStyleQuiz && specialStyleQuiz[currentLang] && currentResult.class){
+    specialStyleNode = specialStyleQuiz[currentLang][currentResult.class];
+  } else {
+    specialStyleNode = null;
   }
   familiarNode = null;
   updateStaticText();
@@ -461,6 +476,18 @@ submitBtn.addEventListener('click', async () => {
     const val = document.querySelector('input[name="subclass"]:checked');
     if(!val) return;
     currentResult.subclass = val.value;
+    if(subCategoryQuiz && subCategoryQuiz[currentLang] && subCategoryQuiz[currentLang][currentResult.class]){
+      subCategoryNode = subCategoryQuiz[currentLang][currentResult.class];
+      stage = 4;
+      renderQuiz();
+      return;
+    }
+    if(specialStyleQuiz && specialStyleQuiz[currentLang] && specialStyleQuiz[currentLang][currentResult.class]){
+      specialStyleNode = specialStyleQuiz[currentLang][currentResult.class];
+      stage = 4;
+      renderQuiz();
+      return;
+    }
     const styleRoot = getStyleRoot();
     if(styleRoot){
       styleNode = styleRoot;
@@ -474,6 +501,66 @@ submitBtn.addEventListener('click', async () => {
     return;
   }
   if(stage === 4){
+    if(subCategoryNode){
+      const val = document.querySelector('input[name="subcategory"]:checked');
+      if(!val) return;
+      currentResult.subcategoryName = subCategoryNode.name;
+      currentResult.subcategory = val.value;
+      subCategoryNode = null;
+      if(currentResult.subcategory === 'Pact of the Chain' && familiarQuiz){
+        familiarNode = familiarQuiz[currentLang];
+        renderQuiz();
+        return;
+      }
+      if(specialStyleQuiz && specialStyleQuiz[currentLang] && specialStyleQuiz[currentLang][currentResult.class]){
+        specialStyleNode = specialStyleQuiz[currentLang][currentResult.class];
+        renderQuiz();
+        return;
+      }
+      const styleRoot = getStyleRoot();
+      if(styleRoot){
+        styleNode = styleRoot;
+        styleStack.length = 0;
+        renderQuiz();
+        return;
+      }
+      styleStack.length = 0;
+      stage = 5;
+      renderQuiz();
+      return;
+    }
+    if(specialStyleNode){
+      const val = document.querySelector('input[name="specialstyle"]:checked');
+      if(!val) return;
+      currentResult.specialStyle = val.value;
+      specialStyleNode = null;
+      const styleRoot = getStyleRoot();
+      if(styleRoot){
+        styleNode = styleRoot;
+        styleStack.length = 0;
+        renderQuiz();
+        return;
+      }
+      stage = 5;
+      renderQuiz();
+      return;
+    }
+    if(familiarNode){
+      const val = document.querySelector('input[name="familiar"]:checked');
+      if(!val) return;
+      currentResult.familiar = val.value;
+      familiarNode = null;
+      const styleRoot = getStyleRoot();
+      if(styleRoot){
+        styleNode = styleRoot;
+        styleStack.length = 0;
+        renderQuiz();
+        return;
+      }
+      stage = 5;
+      renderQuiz();
+      return;
+    }
     if(styleNode){
       const val = document.querySelector('input[name="style"]:checked');
       if(!val) return;
@@ -487,41 +574,9 @@ submitBtn.addEventListener('click', async () => {
       if(choice.result){
         currentResult.style = choice.result;
         styleNode = null;
-        if(subCategoryQuiz && subCategoryQuiz[currentLang] && subCategoryQuiz[currentLang][currentResult.class]){
-          subCategoryNode = subCategoryQuiz[currentLang][currentResult.class];
-          renderQuiz();
-          return;
-        }
-        styleStack.length = 0;
         stage = 5;
         renderQuiz();
       }
-      return;
-    }
-    if(subCategoryNode){
-      const val = document.querySelector('input[name="subcategory"]:checked');
-      if(!val) return;
-      currentResult.subcategoryName = subCategoryNode.name;
-      currentResult.subcategory = val.value;
-      subCategoryNode = null;
-      if(currentResult.subcategory === 'Pact of the Chain' && familiarQuiz){
-        familiarNode = familiarQuiz[currentLang];
-        renderQuiz();
-        return;
-      }
-      styleStack.length = 0;
-      stage = 5;
-      renderQuiz();
-      return;
-    }
-    if(familiarNode){
-      const val = document.querySelector('input[name="familiar"]:checked');
-      if(!val) return;
-      currentResult.familiar = val.value;
-      familiarNode = null;
-      styleStack.length = 0;
-      stage = 5;
-      renderQuiz();
       return;
     }
   }
@@ -599,10 +654,23 @@ backBtn.addEventListener('click', () => {
       renderQuiz();
       return;
     }
+    if(specialStyleNode){
+      specialStyleNode = null;
+      if(subCategoryQuiz && subCategoryQuiz[currentLang] && subCategoryQuiz[currentLang][currentResult.class]){
+        subCategoryNode = subCategoryQuiz[currentLang][currentResult.class];
+      }
+      renderQuiz();
+      return;
+    }
     if(subCategoryNode){
       subCategoryNode = null;
       if(styleStack.length > 0){
         styleNode = styleStack.pop();
+        renderQuiz();
+        return;
+      }
+      if(specialStyleQuiz && specialStyleQuiz[currentLang] && specialStyleQuiz[currentLang][currentResult.class]){
+        specialStyleNode = specialStyleQuiz[currentLang][currentResult.class];
         renderQuiz();
         return;
       }
@@ -616,6 +684,16 @@ backBtn.addEventListener('click', () => {
       return;
     }
     styleNode = null;
+    if(specialStyleQuiz && specialStyleQuiz[currentLang] && specialStyleQuiz[currentLang][currentResult.class]){
+      specialStyleNode = specialStyleQuiz[currentLang][currentResult.class];
+      renderQuiz();
+      return;
+    }
+    if(subCategoryQuiz && subCategoryQuiz[currentLang] && subCategoryQuiz[currentLang][currentResult.class]){
+      subCategoryNode = subCategoryQuiz[currentLang][currentResult.class];
+      renderQuiz();
+      return;
+    }
     stage = 3;
     renderQuiz();
     return;
@@ -639,7 +717,8 @@ function restartQuiz(){
     background:null,
     subcategoryName:null,
     subcategory:null,
-    familiar:null
+    familiar:null,
+    specialStyle:null
   };
   speciesNode = null;
   subSpeciesNode = null;
@@ -654,6 +733,7 @@ function restartQuiz(){
   styleStack.length = 0;
   subCategoryNode = null;
   familiarNode = null;
+  specialStyleNode = null;
   subQuestionSpecies = null;
   renderQuiz();
 }

--- a/styleQuestions.js
+++ b/styleQuestions.js
@@ -728,3 +728,27 @@ window.subCategoryQuiz = window.subCategoryQuiz || {
 };
 
 window.familiarQuiz = window.familiarQuiz || { pt: familiarPT, en: familiarEN };
+
+const specialStylePT = {
+  Ranger: {
+    question: 'Vais escolher o estilo de combate Druidic Warrior?',
+    options: { Yes: 'Sim', No: 'Não' }
+  },
+  Paladin: {
+    question: 'Vais escolher o estilo de combate Blessed Warrior?',
+    options: { Yes: 'Sim', No: 'Não' }
+  }
+};
+
+const specialStyleEN = {
+  Ranger: {
+    question: 'Will you take the Druidic Warrior fighting style?',
+    options: { Yes: 'Yes', No: 'No' }
+  },
+  Paladin: {
+    question: 'Will you take the Blessed Warrior fighting style?',
+    options: { Yes: 'Yes', No: 'No' }
+  }
+};
+
+window.specialStyleQuiz = window.specialStyleQuiz || { pt: specialStylePT, en: specialStyleEN };


### PR DESCRIPTION
## Summary
- support special style questions for paladin and ranger
- show subcategory questions before playstyle questions
- adjust back button logic for new order
- add results intro based on preferred ability and reorder sections
- provide copy button for AI prompt

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686cefbc37cc8325b0e597e8c8aafe4b