### PR TITLE
Fix ability sort bug in background step

### DIFF
--- a/script.js
+++ b/script.js
@@ -309,8 +309,11 @@ function getStyleRoot(){
 
 function canonicalAbility(str){
   if(!str) return '';
-  const parts = str.split('+').map(s => s.trim()).sort();
-  return parts.join(' + ');
+  // Normalize spacing but keep the original order of abilities
+  return str
+    .split('+')
+    .map(s => s.trim())
+    .join(' + ');
 }
 
 submitBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- fix ability canonicalization to keep original order when looking up backgrounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cfc045c308325a4fe6bb5252c3ee0