### PR TITLE
Implement nested Dexterity background question

### DIFF
--- a/backgroundQuestions.js
+++ b/backgroundQuestions.js
@@ -32,7 +32,13 @@ const step3pt = {
       question: 'Como usas a tua agilidade?',
       options: {
         A: { label: 'Furtividade e truques.', list: ['Charlatan','Criminal','Wayfarer'] },
-        B: { label: 'Of\u00edcio ou explora\u00e7\u00e3o.', list: ['Artisan','Entertainer','Guide','Sailor','Scribe','Soldier'] }
+        B: {
+          question: 'Qual destes caminhos descreve melhor a tua experi\u00eancia?',
+          options: {
+            A: { label: 'Profiss\u00f5es pr\u00e1ticas ou art\u00edsticas.', list: ['Artisan','Entertainer','Scribe'] },
+            B: { label: 'Explora\u00e7\u00e3o ou treino f\u00edsico.', list: ['Guide','Sailor','Soldier'] }
+          }
+        }
       }
     },
     Strength: {
@@ -93,7 +99,13 @@ const step3en = {
       question: 'How do you use your agility?',
       options: {
         A: { label: 'Stealth and trickery.', list: ['Charlatan','Criminal','Wayfarer'] },
-        B: { label: 'Craft or exploration.', list: ['Artisan','Entertainer','Guide','Sailor','Scribe','Soldier'] }
+        B: {
+          question: 'Which of these paths best describes your experience?',
+          options: {
+            A: { label: 'Practical or artistic trades.', list: ['Artisan','Entertainer','Scribe'] },
+            B: { label: 'Exploration or physical training.', list: ['Guide','Sailor','Soldier'] }
+          }
+        }
       }
     },
     Strength: {


### PR DESCRIPTION
## Summary
- add second-level choices under the Dexterity branch of background questions
- support nested background branch questions in the quiz logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fd5499fdc8325889fb86f3c991f8f