### PR TITLE
Fix species storing in PT

### DIFF
--- a/script.js
+++ b/script.js
@@ -425,7 +425,9 @@ submitBtn.addEventListener('click', async () => {
         renderQuiz();
         return;
       }
-      currentResult.species = choice && choice !== val.value ? choice : val.value;
+      // Store the selected species key rather than the descriptive text
+      // so the results (and AI prompt) always use the English name
+      currentResult.species = val.value;
       subSpeciesNode = null;
       subSpeciesStack.length = 0;
       subQuestionSpecies = null;


### PR DESCRIPTION
## Summary
- ensure species value stored uses key so AI prompt stays English

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68711259cdd88325ae34a4c7758ac269