### PR TITLE
Add start screen translations and fix layout

### DIFF
--- a/data.js
+++ b/data.js
@@ -395,6 +395,19 @@ const miscText = {
   }
 };
 
+const startText = {
+  pt: {
+    title: 'Descobre a tua personagem ideal de Dungeons & Dragons!',
+    button: 'Começar',
+    footnote: 'Este quiz visa as mais recentes regras de Dungeons & Dragons e assume as seguintes opções de criação de personagem: todo o conteúdo do Player\'s Handbook 2024, todas as espécies do Mordenkainen Presents: Monsters of the Multiverse exceto as que foram revistas pelo Player\'s Handbook 2024 e todas as subclasses e espécies introduzidas pelo Valda’s Spire of Secrets: Player Pack conforme publicado pelo D&D Beyond.'
+  },
+  en: {
+    title: 'Discover your ideal Dungeons & Dragons character!',
+    button: 'Start',
+    footnote: 'This quiz uses the latest Dungeons & Dragons rules and assumes the following character creation options: all content from the 2024 Player\'s Handbook, all species from Mordenkainen Presents: Monsters of the Multiverse except those revised by the 2024 Player\'s Handbook, and all subclasses and species introduced by Valda\u2019s Spire of Secrets: Player Pack as published by D&D Beyond.'
+  }
+};
+
 const nameMap = {
   pt: {
     species: {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,17 +7,23 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<button id="restart">Restart</button>
-<h1>D&D Character Quiz</h1>
-<div id="language-select">
-<label for="lang">Language:</label>
-<select id="lang">
-<option value="pt">Português</option>
-<option value="en">English</option>
-</select>
+<div id="start-screen">
+  <h1 id="start-title">Descobre a tua personagem ideal de Dungeons & Dragons!</h1>
+  <div id="language-select">
+    <label for="lang">Language:</label>
+    <select id="lang">
+      <option value="pt">Português</option>
+      <option value="en">English</option>
+    </select>
+  </div>
+  <button id="start">Começar</button>
+  <p id="footnote">Este quiz visa as mais recentes regras de Dungeons & Dragons e assume as seguintes opções de criação de personagem: todo o conteúdo do Player's Handbook 2024, todas as espécies do Mordenkainen Presents: Monsters of the Multiverse exceto as que foram revistas pelo Player's Handbook 2024 e todas as subclasses e espécies introduzidas pelo Valda’s Spire of Secrets: Player Pack conforme publicado pelo D&D Beyond.</p>
 </div>
-<div id="quiz"></div>
-<div id="quiz-controls">
+
+<button id="restart" style="display:none;">Restart</button>
+<h1 id="quiz-title" style="display:none;">D&D Character Quiz</h1>
+<div id="quiz" style="display:none;"></div>
+<div id="quiz-controls" style="display:none;">
   <button id="submit" style="display:none;">Submit</button>
   <button id="back" style="display:none;">Back</button>
 </div>

--- a/results.js
+++ b/results.js
@@ -257,7 +257,7 @@
 
   restartBtn.addEventListener('click', () => {
     sessionStorage.removeItem('dndResults');
-    window.location.href = 'index.html';
+    window.location.href = 'index.html?start=1';
   });
 
   render();

--- a/script.js
+++ b/script.js
@@ -3,8 +3,11 @@ const quizDiv = document.getElementById('quiz');
 const submitBtn = document.getElementById('submit');
 const backBtn = document.getElementById('back');
 const restartBtn = document.getElementById('restart');
-const titleEl = document.querySelector('h1');
+const startBtn = document.getElementById('start');
+const startScreen = document.getElementById('start-screen');
+const titleEl = document.getElementById('quiz-title');
 const languageLabel = document.querySelector('#language-select label');
+let started = false;
 let currentLang = 'pt';
 
 const genderQuestions = {
@@ -25,6 +28,13 @@ function updateStaticText(){
   document.title = miscText[currentLang].quizTitle;
   titleEl.textContent = miscText[currentLang].quizTitle;
   languageLabel.textContent = miscText[currentLang].language;
+}
+
+function updateStartScreenText(){
+  document.getElementById('start-title').textContent = startText[currentLang].title;
+  startBtn.textContent = startText[currentLang].button;
+  document.getElementById('footnote').textContent = startText[currentLang].footnote;
+  document.documentElement.lang = currentLang;
 }
 
 let stage = 0;
@@ -269,6 +279,10 @@ function renderQuiz() {
 
 langSelect.addEventListener('change', () => {
   currentLang = langSelect.value;
+  if(!started){
+    updateStartScreenText();
+    return;
+  }
   const locale = data[currentLang];
   if(locale.step1.tree){
     speciesNode = locale.step1.tree;
@@ -919,8 +933,46 @@ function restartQuiz(){
   bgBranch = null;
   bgSubBranch = null;
   subQuestionSpecies = null;
+  started = true;
+  startScreen.style.display = 'none';
+  quizDiv.style.display = 'block';
+  document.getElementById('quiz-controls').style.display = 'block';
+  restartBtn.style.display = 'block';
+  titleEl.style.display = 'block';
+  document.body.insertBefore(document.getElementById('language-select'), quizDiv);
   renderQuiz();
 }
 
 restartBtn.addEventListener('click', restartQuiz);
-renderQuiz();
+
+function showStartScreen(){
+  startScreen.style.display = 'block';
+  quizDiv.style.display = 'none';
+  document.getElementById('quiz-controls').style.display = 'none';
+  restartBtn.style.display = 'none';
+  titleEl.style.display = 'none';
+  startScreen.appendChild(document.getElementById('language-select'));
+  updateStartScreenText();
+  started = false;
+}
+
+function startQuiz(){
+  started = true;
+  startScreen.style.display = 'none';
+  quizDiv.style.display = 'block';
+  document.getElementById('quiz-controls').style.display = 'block';
+  restartBtn.style.display = 'block';
+  titleEl.style.display = 'block';
+  document.body.insertBefore(document.getElementById('language-select'), quizDiv);
+  updateStaticText();
+  renderQuiz();
+}
+
+startBtn.addEventListener('click', startQuiz);
+
+const params = new URLSearchParams(window.location.search);
+if(params.get('start') === '1'){
+  startQuiz();
+} else {
+  showStartScreen();
+}

--- a/style.css
+++ b/style.css
@@ -5,3 +5,5 @@ label {display:block; margin:5px 0;}
 #quiz-controls {margin-top:20px; display:flex; flex-direction:column; align-items:flex-start;}
 #quiz-controls button {margin-bottom:5px;}
 #ai-prompt {width:100%; height:150px;}
+#start-screen {text-align:center; display:flex; flex-direction:column; align-items:center; min-height:100vh;}
+#footnote {margin-top:auto; font-size:0.9em; padding:20px; max-width:600px;}


### PR DESCRIPTION
## Summary
- add language data for start screen
- update script to switch languages before starting the quiz
- keep start screen visible until quiz starts and align footnote to bottom
- tweak start page layout to flex column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687234242ef48325a413bf0c60ac7b14