### PR TITLE
Fix crash when height selection yields undefined option

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,7 +67,12 @@ let bgSubBranch = null;
 
 function renderQuiz() {
   const locale = data[currentLang];
-  const strip = txt => txt.replace(/\s*\([^)]*\)\s*$/, '');
+  const strip = txt => {
+    if (typeof txt !== 'string') {
+      return txt ? String(txt) : '';
+    }
+    return txt.replace(/\s*\([^)]*\)\s*$/, '');
+  };
   updateStaticText();
   quizDiv.innerHTML = '';
   let html = '';


### PR DESCRIPTION
## Summary
- handle non-string values in `strip` utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68776849f96c83258e66697be4d3e311