### PR TITLE
Update start page localization and footnote behavior

### DIFF
--- a/data.js
+++ b/data.js
@@ -382,7 +382,10 @@ const miscText = {
     notChosen: 'Por escolher',
     quizTitle: 'Questionário de Personagem de D&D',
     resultsTitle: 'Resultados do Questionário',
-    promptIntro: 'Cola este prompt num gerador de arte IA para visualizares a tua personagem!'
+    promptIntro: 'Cola este prompt num gerador de arte IA para visualizares a tua personagem!',
+    startTitle: 'Descobre a tua personagem ideal de Dungeons & Dragons!',
+    startButton: 'Começar',
+    footnote: 'Este quiz visa as mais recentes regras de Dungeons & Dragons e assume as seguintes opções de criação de personagem: todo o conteúdo do Player\'s Handbook 2024, todas as espécies do Mordenkainen Presents: Monsters of the Multiverse exceto as que foram revistas pelo Player\'s Handbook 2024 e todas as subclasses e espécies introduzidas pelo Valda’s Spire of Secrets: Player Pack conforme publicado pelo D&D Beyond. Quiz feito por Diogo Correia, 2025.'
   },
   en: {
     noResults: 'No results available.',
@@ -391,7 +394,10 @@ const miscText = {
     notChosen: 'Yet to be chosen',
     quizTitle: 'D&D Character Quiz',
     resultsTitle: 'Quiz Results',
-    promptIntro: 'Paste this prompt into an AI art generator to visualize your character!'
+    promptIntro: 'Paste this prompt into an AI art generator to visualize your character!',
+    startTitle: 'Discover your ideal Dungeons & Dragons character!',
+    startButton: 'Start',
+    footnote: 'This quiz targets the latest Dungeons & Dragons rules and assumes the following character creation options: all content from the Player\'s Handbook 2024, all species from Mordenkainen Presents: Monsters of the Multiverse except those revised by the Player\'s Handbook 2024 and all subclasses and species introduced in Valda’s Spire of Secrets: Player Pack as published on D&D Beyond. Quiz by Diogo Correia, 2025.'
   }
 };
 

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@ const startBtn = document.getElementById('start');
 const startScreen = document.getElementById('start-screen');
 const titleEl = document.getElementById('quiz-title');
 const languageLabel = document.querySelector('#language-select label');
+const startTitleEl = document.getElementById('start-title');
+const footnoteEl = document.getElementById('footnote');
 let started = false;
 let currentLang = 'pt';
 
@@ -28,6 +30,9 @@ function updateStaticText(){
   document.title = miscText[currentLang].quizTitle;
   titleEl.textContent = miscText[currentLang].quizTitle;
   languageLabel.textContent = miscText[currentLang].language;
+  if(startTitleEl) startTitleEl.textContent = miscText[currentLang].startTitle;
+  if(startBtn) startBtn.textContent = miscText[currentLang].startButton;
+  if(footnoteEl) footnoteEl.textContent = miscText[currentLang].footnote;
 }
 
 let stage = 0;
@@ -272,6 +277,7 @@ function renderQuiz() {
 
 langSelect.addEventListener('change', () => {
   currentLang = langSelect.value;
+  updateStaticText();
   if(!started) return;
   const locale = data[currentLang];
   if(locale.step1.tree){
@@ -930,6 +936,7 @@ function restartQuiz(){
   restartBtn.style.display = 'block';
   titleEl.style.display = 'block';
   document.body.insertBefore(document.getElementById('language-select'), quizDiv);
+  if(footnoteEl) footnoteEl.style.display = 'none';
   renderQuiz();
 }
 
@@ -941,7 +948,9 @@ function showStartScreen(){
   document.getElementById('quiz-controls').style.display = 'none';
   restartBtn.style.display = 'none';
   titleEl.style.display = 'none';
+  if(footnoteEl) footnoteEl.style.display = 'block';
   startScreen.appendChild(document.getElementById('language-select'));
+  updateStaticText();
 }
 
 function startQuiz(){
@@ -952,6 +961,7 @@ function startQuiz(){
   restartBtn.style.display = 'block';
   titleEl.style.display = 'block';
   document.body.insertBefore(document.getElementById('language-select'), quizDiv);
+  if(footnoteEl) footnoteEl.style.display = 'none';
   renderQuiz();
 }
 


### PR DESCRIPTION
## Summary
- translate start screen and footnote text
- update script to apply translations before the quiz starts
- hide footnote once the quiz begins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687782eb6fc88325906b335986eb75df