### PR TITLE
Create interactive quiz UI for D&D 2024 questionnaire

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
 # dndcharacterquiz
 
-Simple web app for choosing a D&D character species, class and background. Includes PT‑PT and EN translations.
+Aplicação web simples para percorrer o questionário de Dungeons & Dragons 2024 presente no ficheiro `dnd_2024_questionario.json`. O fluxo apresenta uma pergunta de cada vez, permite recuar para alterar respostas e mostra um ecrã de resultados com as variáveis escolhidas.
 
-* Both the English and Portuguese species quizzes now begin with a question about character height, leading through identical decision trees in each language.
-* Questions in the class and background sections are shown one at a time, letting you advance through the quiz page by page.
-* The results page displays Portuguese names for species, classes and backgrounds when that language is selected.
+## Pré-requisitos
 
-## Usage
+* [Node.js](https://nodejs.org/) 18 ou superior
 
-1. Start the server:
+## Como executar
 
-```bash
-node server.js
-```
+1. Instala as dependências (não há dependências externas, este passo serve apenas para inicializar o projecto caso seja necessário):
 
-2. Open `http://localhost:3000` in your browser.
+   ```bash
+   npm install
+   ```
+
+2. Arranca o servidor de desenvolvimento:
+
+   ```bash
+   node server.js
+   ```
+
+3. Abre [http://localhost:3000](http://localhost:3000) no teu navegador preferido.
+
+4. Responde às perguntas. Usa o botão **Anterior** para recuar se quiseres rever alguma resposta. Depois da última pergunta será mostrado o ecrã de resultados com o resumo das tuas escolhas.
+
+## Estrutura
+
+* `index.html` – página principal da aplicação.
+* `style.css` – estilos globais.
+* `app.js` – lógica do questionário (carregamento do JSON, navegação, cálculo de resultados).
+* `server.js` – servidor HTTP mínimo para servir os ficheiros estáticos.
+* `dnd_2024_questionario.json` – fonte de dados do questionário.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,499 @@
+const languageFromLocale = (locale) => {
+  if (!locale) return 'pt';
+  const [lang] = locale.split('-');
+  return lang || 'pt';
+};
+
+class QuizApp {
+  constructor(quizData) {
+    this.quizData = quizData;
+    this.language = languageFromLocale(quizData.locale);
+    this.state = {
+      variables: this.cloneValue(quizData.metadata?.initial_state ?? {}),
+      currentNodeId: null,
+      history: [],
+    };
+
+    this.dom = {
+      questionScreen: document.getElementById('question-screen'),
+      resultScreen: document.getElementById('result-screen'),
+      progress: document.getElementById('progress-indicator'),
+      questionText: document.getElementById('question-text'),
+      optionsForm: document.getElementById('options-form'),
+      noOptionsMessage: document.getElementById('no-options-message'),
+      backButton: document.getElementById('back-button'),
+      nextButton: document.getElementById('next-button'),
+      resultsContainer: document.getElementById('results-container'),
+      restartButton: document.getElementById('restart-button'),
+    };
+
+    this.sectionVariables = this.buildSectionVariables();
+    this.currentOptions = [];
+    this.selectedValue = null;
+    this.attachEventListeners();
+    this.start();
+  }
+
+  attachEventListeners() {
+    this.dom.nextButton.addEventListener('click', () => this.goForward());
+    this.dom.backButton.addEventListener('click', () => this.goBack());
+    this.dom.restartButton.addEventListener('click', () => this.restart());
+  }
+
+  start() {
+    this.state.currentNodeId = null;
+    this.state.history = [];
+    this.state.variables = this.cloneValue(this.quizData.metadata?.initial_state ?? {});
+    this.showQuestion(this.quizData.root);
+  }
+
+  restart() {
+    this.toggleScreens('question');
+    this.start();
+  }
+
+  toggleScreens(target) {
+    const showQuestion = target === 'question';
+    this.dom.questionScreen.toggleAttribute('hidden', !showQuestion);
+    this.dom.resultScreen.toggleAttribute('hidden', showQuestion);
+    this.dom.questionScreen.classList.toggle('card--hidden', !showQuestion);
+    this.dom.resultScreen.classList.toggle('card--hidden', showQuestion);
+  }
+
+  goBack() {
+    if (!this.state.history.length) {
+      return;
+    }
+    const lastEntry = this.state.history.pop();
+    this.state.variables = this.cloneValue(lastEntry.stateBefore);
+    this.showQuestion(lastEntry.nodeId, { preselect: lastEntry.selectedValue, fromHistory: true });
+  }
+
+  goForward() {
+    if (!this.selectedValue) {
+      return;
+    }
+
+    const nodeId = this.state.currentNodeId;
+    const node = this.quizData.nodes[nodeId];
+    const option = this.currentOptions.find((opt) => opt.value === this.selectedValue);
+
+    if (!node || !option) {
+      return;
+    }
+
+    const stateBefore = this.cloneValue(this.state.variables);
+    this.applyActions(option.set, { option });
+    this.applyActions(node.on_select, { option });
+
+    this.state.history.push({
+      nodeId,
+      selectedValue: option.value,
+      stateBefore,
+    });
+
+    const nextNodeId = option.next ?? node.next ?? null;
+    this.showQuestion(nextNodeId);
+  }
+
+  showQuestion(startNodeId, { preselect = null, fromHistory = false } = {}) {
+    const resolution = this.resolveNextQuestion(startNodeId);
+    if (!resolution) {
+      this.showResults();
+      return;
+    }
+
+    const { nodeId, node, options } = resolution;
+    this.state.currentNodeId = nodeId;
+    this.currentOptions = options;
+    this.selectedValue = preselect;
+
+    this.dom.progress.textContent = `Pergunta ${this.state.history.length + 1}`;
+    this.dom.questionText.textContent = node.question;
+
+    this.renderOptions(options, preselect);
+    this.dom.noOptionsMessage.hidden = options.length > 0;
+    this.dom.nextButton.disabled = !preselect;
+    this.dom.backButton.disabled = this.state.history.length === 0;
+
+    if (!options.length) {
+      this.dom.nextButton.disabled = true;
+    }
+
+    if (!fromHistory) {
+      this.dom.optionsForm.focus?.();
+    }
+  }
+
+  showResults() {
+    this.toggleScreens('result');
+    this.renderResults();
+  }
+
+  resolveNextQuestion(startNodeId) {
+    let nodeId = startNodeId;
+    while (nodeId) {
+      const node = this.quizData.nodes[nodeId];
+      if (!node) {
+        return null;
+      }
+
+      if (node.when && !this.evaluateCondition(node.when)) {
+        nodeId = node.next ?? null;
+        continue;
+      }
+
+      if (node.type !== 'question') {
+        nodeId = node.next ?? null;
+        continue;
+      }
+
+      if (node.autoselect_if_single) {
+        const autoOptions = this.buildOptions(node, { includeDatasetEntry: true });
+        if (autoOptions.length === 1) {
+          const result = autoOptions[0];
+          this.applyActions(node.autoselect_if_single.set, {
+            resultValue: result.value,
+            result: result.datasetEntry,
+          });
+          nodeId = node.autoselect_if_single.skip_to ?? node.next ?? null;
+          continue;
+        }
+      }
+
+      const options = this.buildOptions(node, { includeDatasetEntry: true });
+      return { nodeId, node, options };
+    }
+
+    return null;
+  }
+
+  buildOptions(node, { includeDatasetEntry = false } = {}) {
+    if (Array.isArray(node.options)) {
+      return node.options.map((opt, index) => ({
+        ...opt,
+        index,
+      }));
+    }
+
+    const source = node.options_source;
+    if (!source) {
+      return [];
+    }
+
+    if (source.type !== 'inline') {
+      return [];
+    }
+
+    const dataset = this.quizData.metadata?.datasets?.[source.dataset] ?? [];
+    const filtered = dataset.filter((entry) => this.passesFilters(entry, source.filters ?? []));
+
+    const seen = new Set();
+    const options = [];
+
+    for (const entry of filtered) {
+      const value = entry[source.value_field];
+      const label = entry[source.label_field];
+
+      if (source.distinct && seen.has(value)) {
+        continue;
+      }
+
+      seen.add(value);
+      const option = {
+        label,
+        value,
+      };
+
+      if (includeDatasetEntry) {
+        option.datasetEntry = entry;
+      }
+
+      options.push(option);
+    }
+
+    return options;
+  }
+
+  passesFilters(entry, filters) {
+    if (!filters?.length) {
+      return true;
+    }
+
+    return filters.every((filter) => {
+      const { field, var: variableName, op, optional } = filter;
+      const variableValue = this.state.variables[variableName];
+
+      if ((variableValue === undefined || variableValue === null || variableValue === '') && optional) {
+        return true;
+      }
+
+      if (variableValue === undefined || variableValue === null || variableValue === '') {
+        return false;
+      }
+
+      const entryValue = entry[field];
+      switch (op) {
+        case 'contains': {
+          if (!Array.isArray(entryValue)) {
+            return false;
+          }
+          return entryValue.includes(variableValue);
+        }
+        case 'in_list': {
+          if (!Array.isArray(variableValue)) {
+            return false;
+          }
+          return variableValue.includes(entryValue);
+        }
+        default:
+          return false;
+      }
+    });
+  }
+
+  evaluateCondition(condition) {
+    if (!condition) {
+      return true;
+    }
+
+    if (Array.isArray(condition.all)) {
+      return condition.all.every((c) => this.evaluateCondition(c));
+    }
+
+    if (Array.isArray(condition.any)) {
+      return condition.any.some((c) => this.evaluateCondition(c));
+    }
+
+    const variableValue = this.state.variables[condition.var];
+    switch (condition.op) {
+      case 'eq':
+        return variableValue === condition.value;
+      default:
+        return true;
+    }
+  }
+
+  renderOptions(options, preselectValue) {
+    this.dom.optionsForm.innerHTML = '';
+    options.forEach((option, index) => {
+      const optionId = `option-${index}`;
+      const wrapper = document.createElement('label');
+      wrapper.className = 'option';
+      wrapper.setAttribute('for', optionId);
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'quiz-option';
+      input.value = option.value;
+      input.id = optionId;
+      input.className = 'option__input';
+      input.checked = option.value === preselectValue;
+      input.addEventListener('change', () => {
+        this.selectedValue = input.value;
+        this.dom.nextButton.disabled = false;
+      });
+
+      const label = document.createElement('p');
+      label.className = 'option__label';
+      label.textContent = option.label;
+
+      wrapper.append(input, label);
+      this.dom.optionsForm.appendChild(wrapper);
+    });
+
+    if (!options.length) {
+      this.selectedValue = null;
+      this.dom.nextButton.disabled = true;
+    }
+  }
+
+  renderResults() {
+    const localeKey = this.language === 'pt' ? 'pt' : 'en';
+    this.dom.resultsContainer.innerHTML = '';
+
+    const sectionsMeta = this.quizData.metadata?.sections ?? {};
+    const valueMap = this.quizData.metadata?.value_map ?? {};
+    const variableSchemas = this.quizData.metadata?.variables ?? {};
+
+    Object.entries(sectionsMeta).forEach(([sectionKey, translations]) => {
+      const variables = Array.from(this.sectionVariables.get(sectionKey) ?? []).filter((variableName) => {
+        const schema = variableSchemas[variableName];
+        return !schema || schema.type !== 'array';
+      });
+
+      if (!variables.length) {
+        return;
+      }
+
+      const sectionElement = document.createElement('section');
+      sectionElement.className = 'result-section';
+
+      const title = document.createElement('h3');
+      title.className = 'result-section__title';
+      title.textContent = translations[localeKey] ?? translations.pt ?? sectionKey;
+      sectionElement.appendChild(title);
+
+      variables.forEach((variableName) => {
+        const rawValue = this.state.variables[variableName];
+        if (rawValue === undefined) {
+          return;
+        }
+
+        const item = document.createElement('div');
+        item.className = 'result-item';
+
+        const label = document.createElement('span');
+        label.className = 'result-item__label';
+        label.textContent = this.formatVariableLabel(variableName);
+
+        const value = document.createElement('span');
+        value.className = 'result-item__value';
+        value.textContent = this.formatVariableValue(variableName, rawValue, valueMap, localeKey);
+
+        item.append(label, value);
+        sectionElement.appendChild(item);
+      });
+
+      this.dom.resultsContainer.appendChild(sectionElement);
+    });
+  }
+
+  formatVariableLabel(variableName) {
+    const map = {
+      gender: 'Género',
+      height: 'Altura',
+      species_commonality: 'Comum/Exótico',
+      animal_likeness: 'Traços animais',
+      species_theme: 'Tema',
+      species: 'Espécie',
+      class_complexity: 'Complexidade da classe',
+    };
+    return map[variableName] ?? variableName;
+  }
+
+  formatVariableValue(variableName, rawValue, valueMap, localeKey) {
+    if (rawValue === null || rawValue === undefined) {
+      return '—';
+    }
+
+    if (Array.isArray(rawValue)) {
+      return rawValue.join(', ');
+    }
+
+    const variableMap = valueMap?.[variableName];
+    if (variableMap && variableMap[rawValue]) {
+      const entry = variableMap[rawValue];
+      return entry[localeKey] ?? entry.pt ?? String(rawValue);
+    }
+
+    if (variableName === 'species') {
+      const dataset = this.quizData.metadata?.datasets?.species ?? [];
+      const match = dataset.find((entry) => entry.code === rawValue);
+      if (match) {
+        return match[localeKey] ?? match.pt ?? rawValue;
+      }
+    }
+
+    return String(rawValue);
+  }
+
+  buildSectionVariables() {
+    const map = new Map();
+    const ensureSection = (section) => {
+      if (!map.has(section)) {
+        map.set(section, new Set());
+      }
+      return map.get(section);
+    };
+
+    Object.values(this.quizData.nodes).forEach((node) => {
+      if (node.type !== 'question' || !node.section) {
+        return;
+      }
+
+      const sectionSet = ensureSection(node.section);
+      const collect = (actions) => {
+        if (!Array.isArray(actions)) {
+          return;
+        }
+        actions.forEach((action) => {
+          if (action?.var) {
+            sectionSet.add(action.var);
+          }
+        });
+      };
+
+      (node.options ?? []).forEach((option) => collect(option.set));
+      collect(node.on_select);
+      if (node.autoselect_if_single) {
+        collect(node.autoselect_if_single.set);
+      }
+
+      if (node.options_source) {
+        // Dynamic options may still feed into on_select, so ensure at least the target variable is captured.
+        collect(node.on_select);
+      }
+    });
+
+    return map;
+  }
+
+  applyActions(actions, context = {}) {
+    if (!Array.isArray(actions)) {
+      return;
+    }
+
+    actions.forEach((action) => {
+      if (!action || action.op !== 'set' || !action.var) {
+        return;
+      }
+
+      let value;
+      if (action.value_from_option) {
+        value = context.option?.value;
+      } else if (action.value_from_result) {
+        value = context.resultValue ?? context.result?.[action.value_field];
+      } else {
+        value = action.value;
+      }
+
+      this.state.variables[action.var] = this.cloneValue(value);
+    });
+  }
+
+  cloneValue(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+
+    return JSON.parse(JSON.stringify(value));
+  }
+}
+
+const bootstrap = async () => {
+  const loadingMessage = 'A carregar questionário…';
+  document.getElementById('question-text').textContent = loadingMessage;
+  try {
+    const response = await fetch('dnd_2024_questionario.json');
+    if (!response.ok) {
+      throw new Error(`Falha ao carregar o questionário: ${response.status}`);
+    }
+    const data = await response.json();
+    new QuizApp(data);
+  } catch (error) {
+    const message = document.createElement('p');
+    message.className = 'options__empty';
+    message.textContent = 'Não foi possível carregar o questionário. Atualiza a página ou verifica o servidor.';
+    const container = document.getElementById('options-form');
+    container.innerHTML = '';
+    container.appendChild(message);
+    console.error(error);
+  }
+};
+
+bootstrap();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="pt">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>D&D 2024 Quiz</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app" class="app">
+      <header class="app__header">
+        <h1 class="app__title">Descobre a tua personagem de D&D 2024</h1>
+        <p class="app__subtitle">
+          Responde às perguntas para encontrares a combinação ideal de género, espécie e classe.
+        </p>
+      </header>
+      <main class="app__main">
+        <section id="question-screen" class="card" aria-live="polite">
+          <div class="card__progress" id="progress-indicator"></div>
+          <h2 class="card__question" id="question-text"></h2>
+          <form class="options" id="options-form" role="radiogroup" aria-describedby="question-text"></form>
+          <p class="options__empty" id="no-options-message" hidden>
+            Não encontrámos opções compatíveis com as tuas escolhas. Volta atrás e ajusta as respostas anteriores.
+          </p>
+          <div class="card__actions">
+            <button type="button" class="btn btn--secondary" id="back-button">&larr; Anterior</button>
+            <button type="button" class="btn btn--primary" id="next-button" disabled>Seguinte &rarr;</button>
+          </div>
+        </section>
+        <section id="result-screen" class="card card--hidden" hidden>
+          <h2 class="card__question">Resultados</h2>
+          <p class="card__intro">
+            Eis as tuas escolhas ao longo do questionário. Podes voltar atrás para alterar respostas ou recomeçar.
+          </p>
+          <div id="results-container" class="results"></div>
+          <div class="card__actions card__actions--center">
+            <button type="button" class="btn btn--secondary" id="restart-button">Recomeçar</button>
+          </div>
+        </section>
+      </main>
+    </div>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "dndcharacterquiz",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dndcharacterquiz",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dndcharacterquiz",
+  "version": "1.0.0",
+  "description": "Quiz web app para o questionário D&D 2024",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,57 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+const rootDir = __dirname;
+
+const mimeTypes = {
+  '.html': 'text/html; charset=UTF-8',
+  '.css': 'text/css; charset=UTF-8',
+  '.js': 'application/javascript; charset=UTF-8',
+  '.json': 'application/json; charset=UTF-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+};
+
+const server = http.createServer((req, res) => {
+  const safePath = path.normalize(req.url).replace(/^\/+/, '');
+  let filePath = path.join(rootDir, safePath);
+
+  if (!safePath) {
+    filePath = path.join(rootDir, 'index.html');
+  }
+
+  fs.stat(filePath, (statErr, stats) => {
+    if (statErr) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=UTF-8' });
+      res.end('404 Not Found');
+      return;
+    }
+
+    let resolvedPath = filePath;
+    if (stats.isDirectory()) {
+      resolvedPath = path.join(filePath, 'index.html');
+    }
+
+    const ext = path.extname(resolvedPath).toLowerCase();
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+    fs.readFile(resolvedPath, (readErr, content) => {
+      if (readErr) {
+        res.writeHead(500, { 'Content-Type': 'text/plain; charset=UTF-8' });
+        res.end('500 Internal Server Error');
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    });
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Servidor disponível em http://localhost:${port}`);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,279 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f7f5ff;
+  --bg-dark: #1c1b29;
+  --card: #ffffff;
+  --card-dark: #2a283d;
+  --primary: #5a3fd9;
+  --primary-dark: #a89bff;
+  --text: #201b3a;
+  --text-dark: #f1efff;
+  --muted: #5f5b77;
+  --muted-dark: #c5c0e1;
+  --border: rgba(90, 63, 217, 0.15);
+  --border-dark: rgba(168, 155, 255, 0.3);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--bg) 0%, #ece7ff 100%);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: linear-gradient(135deg, var(--bg-dark) 0%, #100f1a 100%);
+    color: var(--text-dark);
+  }
+}
+
+.app {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app__header {
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.app__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw + 1rem, 2.8rem);
+}
+
+.app__subtitle {
+  margin-top: 0.5rem;
+  color: var(--muted);
+}
+
+.card {
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  border-radius: 18px;
+  padding: 2rem clamp(1rem, 5vw, 2.5rem);
+  box-shadow: 0 24px 48px rgba(32, 27, 58, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    background: color-mix(in srgb, var(--card-dark) 96%, transparent);
+    box-shadow: 0 24px 48px rgba(15, 12, 30, 0.55);
+  }
+}
+
+.card--hidden {
+  display: none;
+}
+
+.card__progress {
+  font-weight: 600;
+  color: var(--primary);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card__progress {
+    color: var(--primary-dark);
+  }
+}
+
+.card__question {
+  margin: 0;
+  font-size: clamp(1.25rem, 1vw + 1.2rem, 1.7rem);
+}
+
+.card__intro {
+  margin: 0;
+  color: var(--muted);
+}
+
+.options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: white;
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.option:hover,
+.option:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 12px 24px rgba(32, 27, 58, 0.18);
+  transform: translateY(-1px);
+}
+
+@media (prefers-color-scheme: dark) {
+  .option {
+    background: color-mix(in srgb, var(--card-dark) 92%, transparent);
+    border-color: var(--border-dark);
+  }
+}
+
+.option__input {
+  accent-color: var(--primary);
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.option__label {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.options__empty {
+  margin: 0;
+  color: #b3261e;
+  font-weight: 600;
+}
+
+@media (prefers-color-scheme: dark) {
+  .options__empty {
+    color: #ffb4ab;
+  }
+}
+
+.card__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.card__actions--center {
+  justify-content: center;
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn--primary {
+  background: var(--primary);
+  color: white;
+  box-shadow: 0 16px 28px rgba(90, 63, 217, 0.35);
+}
+
+.btn--primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(90, 63, 217, 0.4);
+}
+
+.btn--secondary {
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--border);
+}
+
+.btn--secondary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(32, 27, 58, 0.12);
+}
+
+.results {
+  display: grid;
+  gap: 1rem;
+}
+
+.result-section {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.2rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+@media (prefers-color-scheme: dark) {
+  .result-section {
+    background: color-mix(in srgb, var(--card-dark) 92%, transparent);
+    border-color: var(--border-dark);
+  }
+}
+
+.result-section__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+  color: var(--primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .result-section__title {
+    color: var(--primary-dark);
+  }
+}
+
+.result-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid rgba(32, 27, 58, 0.08);
+}
+
+.result-item:first-child {
+  border-top: none;
+}
+
+.result-item__label {
+  font-weight: 600;
+}
+
+.result-item__value {
+  text-align: right;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 1.5rem 0.75rem 2.5rem;
+  }
+
+  .card__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .result-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .result-item__value {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page quiz experience that loads `dnd_2024_questionario.json`, supports back navigation, and shows a result summary
- add styling for the quiz and results screens along with a restart action
- introduce a minimal Node.js static server plus project metadata and updated documentation

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a6d9a8cc8325b5f50880d89bcf4f